### PR TITLE
Fix/mpettest

### DIFF
--- a/bin/mpettest.py
+++ b/bin/mpettest.py
@@ -11,7 +11,7 @@ args=run_tests.main()
 #Create the list of arguments for pytest
 pytest_args=["--baseDir="+osp.join(args.test_dir,"ref_outputs"),
              "--modDir="+args.output_dir,
-             "tests/compare_tests.py"
+             osp.join(osp.dirname(osp.abspath(__file__)),"../tests/compare_tests.py")
             ]
 
 #Add addtional options if a test list was provided

--- a/bin/mpettest.py
+++ b/bin/mpettest.py
@@ -2,17 +2,23 @@
 
 import os
 import os.path as osp
-import sys
-import time
+import pytest
+import run_tests
 
-import tests.test_suite as tst
+#Run the tests and save the input args
+args=run_tests.main()
 
-if len(sys.argv) > 1:
-    compareDir = osp.join(os.getcwd(), sys.argv[1])
-else:
-    compareDir = None
-timeStart = time.time()
-tst.main(compareDir)
-timeEnd = time.time()
-tTot = timeEnd - timeStart
-print("Total test time:", tTot, "s")
+#Create the list of arguments for pytest
+pytest_args=["--baseDir="+osp.join(args.test_dir,"ref_outputs"),
+             "--modDir="+args.output_dir,
+             "tests/compare_tests.py"
+            ]
+
+#Add addtional options if a test list was provided
+if args.tests:
+    pytest_args.append("--tests="+" ".join(args.tests))
+    pytest_args.append("--skip-analytic")
+
+
+#Run pytest
+pytest.main(pytest_args)

--- a/bin/run_locally.sh
+++ b/bin/run_locally.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-#Add test dir to environment
-export PYTHONPATH=$PYTHONPATH:$( dirname "${BASH_SOURCE[0]}" )/../tests
-
-#pass through to test script
-python ./bin/run_tests.py --test_dir $( dirname "${BASH_SOURCE[0]}" )/../tests $@

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -39,16 +39,21 @@ def run(test_outputs, testDir, tests=None):
     if not tests:
       run_test_sims_analyt(runInfoAnalyt, dirDict)
 
-if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='Run test suite.')
-  parser.add_argument('--output_dir', metavar='o', type=str,
-      default=osp.join(osp.dirname(osp.abspath(__file__)),"../tests",
-        "test_outputs", time.strftime("%Y%m%d_%H%M%S") ),
-                    help='where to put the simulations, default is tests/tests_outputs/date')
-  parser.add_argument('--test_dir', metavar='t', type=str, 
-      default=osp.join(osp.dirname(osp.abspath(__file__)),"tests"),
-                    help='where are the tests located?')
-  parser.add_argument('tests', nargs='*', default=[], help='which tests do I run?')
-  args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser(description='Run test suite.')
+    parser.add_argument('--output_dir', metavar='o', type=str,
+        default=osp.join(osp.dirname(osp.abspath(__file__)),"../tests",
+          "test_outputs", time.strftime("%Y%m%d_%H%M%S") ),
+                      help='where to put the simulations, default is tests/tests_outputs/date')
+    parser.add_argument('--test_dir', metavar='t', type=str, 
+        default=osp.join(osp.dirname(osp.abspath(__file__)),"tests"),
+                      help='where are the tests located?')
+    parser.add_argument('tests', nargs='*', default=[], help='which tests do I run?')
+    args = parser.parse_args()
 
-  run(args.output_dir,args.test_dir, args.tests)
+    run(args.output_dir,args.test_dir, args.tests)
+
+    return(args)
+
+if __name__ == "__main__":
+    main()

--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -46,7 +46,7 @@ def main():
           "test_outputs", time.strftime("%Y%m%d_%H%M%S") ),
                       help='where to put the simulations, default is tests/tests_outputs/date')
     parser.add_argument('--test_dir', metavar='t', type=str, 
-        default=osp.join(osp.dirname(osp.abspath(__file__)),"tests"),
+        default=osp.join(osp.dirname(osp.abspath(__file__)),"../tests"),
                       help='where are the tests located?')
     parser.add_argument('tests', nargs='*', default=[], help='which tests do I run?')
     args = parser.parse_args()

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,12 +2,10 @@
 
 When adding new features or making changes to the code, it's helpful to run a suite of tests to make sure various things are behaving as expected. This should not be necessary for users who are not changing the code at all, although it could still be nice to verify that the outputs users are seeing match those the developers expect for a few specific cases.
 
-To run the tests, execute ./bin/run\_locally.sh from the repository root. with
-the -h flag you can see which arguments are accepted.  This will run a number of
-simulations and store the results.
+To run the tests, execute `PYTHONPATH=. ./bin/mpettest.py` from the repository root. The `-h` flag shows which arguments are accepted.  This will run a number of
+simulations and test the results.
 
-To compare these outputs you can use pytest.
-
+To compare the output manually you can use pytest:
 ```bash
   pytest --baseDir=tests/ref_outputs/ --modDir=tests/test_outputs/20201208_154137/ tests/compare_tests.py
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,11 @@ def pytest_generate_tests(metafunc):
       metafunc.parametrize("Dirs", [ (dir_b + '/test{:03}'.format(i),
           dir_t + '/test{:03}'.format(i))for i in range(1, ntests+1)])
     else:
-      metafunc.parametrize("Dirs", [ (dir_b + "/" + test, dir_t + "/" + test) for test in metafunc.config.getoption("tests")])
+      #Sometimes the tests option is a list, other times it is an array with one element (a string of tests).
+      #This handles both.
+      tests_str=" ".join(metafunc.config.getoption("tests"))
+      tests_lst=tests_str.split()
+      metafunc.parametrize("Dirs", [ (dir_b + "/" + test, dir_t + "/" + test) for test in tests_lst])
   if "tol" in metafunc.fixturenames:
     metafunc.parametrize("tol", [float(metafunc.config.getoption("tolerance"))])
   if "testDir" in metafunc.fixturenames:


### PR DESCRIPTION
I updated mpettest.py to run the new testing suite and then immediately check the results with pytest. A custom list of tests can be passed as a command line argument.

I think mpettest.py and run_tests.py could eventually be combined into one file, with a flag to specify whether or not to call pytest.